### PR TITLE
Use 'X-Forwarded-For' header as the remote IP if it exists.

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,9 @@ function middleware (req, res, next) {
   
   function _getRemoteAddress (callback) {
     var rc = req.connection
-    if (req.socket && req.socket.remoteAddress) 
+    if (req.header('x-forwarded-for'))
+      callback(req.header('x-forwarded-for'))
+    else if (req.socket && req.socket.remoteAddress) 
       callback(req.socket.remoteAddress)
     else if (rc) 
       if (rc.remoteAddress)


### PR DESCRIPTION
We're using the 'bouncy' NPM module in front our node apps and noticed that all of our remote addresses were being recorded as '127.0.0.1'. This addition will use the X-Forwarded-For header as the remote/client IP address if it exists. This should also work if the proxy server is Nginx or another web server adding the original IP address with X-Forwarded-For.
